### PR TITLE
feat(#6): Add health check endpoint to Spring Boot app

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.0</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>demo</name>
+    <description>Spring Boot Learning Repo</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/demo/controller/HealthController.java
+++ b/src/main/java/com/example/demo/controller/HealthController.java
@@ -1,0 +1,24 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.HealthResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+
+@RestController
+@RequestMapping("/health")
+public class HealthController {
+
+    @GetMapping
+    public ResponseEntity<HealthResponse> getHealth() {
+        HealthResponse response = new HealthResponse(
+                "UP",
+                Instant.now().toString(),
+                "spring-boot-app"
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/demo/model/HealthResponse.java
+++ b/src/main/java/com/example/demo/model/HealthResponse.java
@@ -1,0 +1,41 @@
+package com.example.demo.model;
+
+public class HealthResponse {
+
+    private String status;
+    private String timestamp;
+    private String service;
+
+    public HealthResponse() {
+    }
+
+    public HealthResponse(String status, String timestamp, String service) {
+        this.status = status;
+        this.timestamp = timestamp;
+        this.service = service;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public void setService(String service) {
+        this.service = service;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.application.name=spring-boot-app
+
+# Actuator configuration
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always

--- a/src/test/java/com/example/demo/controller/HealthControllerTest.java
+++ b/src/test/java/com/example/demo/controller/HealthControllerTest.java
@@ -1,0 +1,49 @@
+package com.example.demo.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(HealthController.class)
+public class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testHealthEndpointReturns200() throws Exception {
+        mockMvc.perform(get("/health")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testHealthEndpointReturnsStatusUp() throws Exception {
+        mockMvc.perform(get("/health")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    @Test
+    public void testHealthEndpointReturnsServiceName() throws Exception {
+        mockMvc.perform(get("/health")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.service").value("spring-boot-app"));
+    }
+
+    @Test
+    public void testHealthEndpointReturnsTimestamp() throws Exception {
+        mockMvc.perform(get("/health")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.timestamp").isNotEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented a custom `/health` endpoint via `HealthController` that returns application status as JSON with `status`, `timestamp`, and `service` fields
- Added Spring Boot Actuator dependency and configured it to expose the standard `/actuator/health` endpoint with full health details
- Added comprehensive unit tests covering HTTP 200 response, status value, service name, and timestamp presence

## Changes
- `src/main/java/com/example/demo/controller/HealthController.java` — Custom health check endpoint
- `src/main/java/com/example/demo/model/HealthResponse.java` — Response model for health status
- `src/test/java/com/example/demo/controller/HealthControllerTest.java` — Unit tests with `@WebMvcTest` and `MockMvc`
- `src/main/resources/application.properties` — Actuator endpoint configuration
- `pom.xml` — Added `spring-boot-starter-actuator` dependency

## Testing
1. Run all tests: `mvn clean install`
2. Run health controller tests only: `mvn test -Dtest=HealthControllerTest`
3. Start the application: `mvn spring-boot:run`
4. Test custom endpoint: `curl -X GET http://localhost:8080/health`
5. Test actuator endpoint: `curl -X GET http://localhost:8080/actuator/health`

Both endpoints should return HTTP 200 with JSON containing `{"status":"UP","timestamp":"...","service":"spring-boot-app"}`

## Issue
Closes #6: Add health check endpoint to Spring Boot app