### PR TITLE
feat(#10): Add validation in patch api age cannot be less than 21 years.

### DIFF
--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -1,0 +1,59 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.User;
+import com.example.demo.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    @Autowired
+    private UserService userService;
+
+    @GetMapping
+    public List<User> getAllUsers() {
+        return userService.getAllUsers();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getUserById(@PathVariable Long id) {
+        return userService.getUserById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<User> createUser(@RequestBody User user) {
+        return ResponseEntity.ok(userService.createUser(user));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<?> patchUser(@PathVariable Long id, @RequestBody Map<String, Object> updates) {
+        if (updates.containsKey("age")) {
+            int age;
+            try {
+                age = Integer.parseInt(updates.get("age").toString());
+            } catch (NumberFormatException e) {
+                return ResponseEntity.badRequest().body(Map.of("error", "Invalid age value"));
+            }
+            if (age < 21) {
+                return ResponseEntity.badRequest().body(Map.of("error", "Age cannot be less than 21 years"));
+            }
+        }
+        return userService.patchUser(id, updates)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/demo/model/User.java
+++ b/src/main/java/com/example/demo/model/User.java
@@ -1,0 +1,37 @@
+package com.example.demo.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String email;
+    private int age;
+
+    public User() {}
+
+    public User(Long id, String name, String email, int age) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.age = age;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public int getAge() { return age; }
+    public void setAge(int age) { this.age = age; }
+}

--- a/src/main/java/com/example/demo/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/demo/service/UserService.java
+++ b/src/main/java/com/example/demo/service/UserService.java
@@ -1,0 +1,48 @@
+package com.example.demo.service;
+
+import com.example.demo.model.User;
+import com.example.demo.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class UserService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+    public Optional<User> getUserById(Long id) {
+        return userRepository.findById(id);
+    }
+
+    public User createUser(User user) {
+        return userRepository.save(user);
+    }
+
+    public Optional<User> patchUser(Long id, Map<String, Object> updates) {
+        return userRepository.findById(id).map(user -> {
+            if (updates.containsKey("name")) {
+                user.setName(updates.get("name").toString());
+            }
+            if (updates.containsKey("email")) {
+                user.setEmail(updates.get("email").toString());
+            }
+            if (updates.containsKey("age")) {
+                user.setAge(Integer.parseInt(updates.get("age").toString()));
+            }
+            return userRepository.save(user);
+        });
+    }
+
+    public void deleteUser(Long id) {
+        userRepository.deleteById(id);
+    }
+}

--- a/src/test/java/com/example/demo/controller/UserControllerPatchValidationTest.java
+++ b/src/test/java/com/example/demo/controller/UserControllerPatchValidationTest.java
@@ -1,0 +1,104 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.User;
+import com.example.demo.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+public class UserControllerPatchValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void patchUser_withAgeLessThan21_returnsBadRequest() throws Exception {
+        Map<String, Object> updates = Map.of("age", 18);
+
+        mockMvc.perform(patch("/users/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Age cannot be less than 21 years"));
+    }
+
+    @Test
+    public void patchUser_withAgeExactly21_returnsOk() throws Exception {
+        Map<String, Object> updates = Map.of("age", 21);
+        User updatedUser = new User(1L, "John", "john@example.com", 21);
+        when(userService.patchUser(eq(1L), any())).thenReturn(Optional.of(updatedUser));
+
+        mockMvc.perform(patch("/users/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.age").value(21));
+    }
+
+    @Test
+    public void patchUser_withAgeGreaterThan21_returnsOk() throws Exception {
+        Map<String, Object> updates = Map.of("age", 30);
+        User updatedUser = new User(1L, "John", "john@example.com", 30);
+        when(userService.patchUser(eq(1L), any())).thenReturn(Optional.of(updatedUser));
+
+        mockMvc.perform(patch("/users/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.age").value(30));
+    }
+
+    @Test
+    public void patchUser_withAge20_returnsBadRequest() throws Exception {
+        Map<String, Object> updates = Map.of("age", 20);
+
+        mockMvc.perform(patch("/users/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Age cannot be less than 21 years"));
+    }
+
+    @Test
+    public void patchUser_withNoAge_returnsOk() throws Exception {
+        Map<String, Object> updates = Map.of("name", "Jane");
+        User updatedUser = new User(1L, "Jane", "jane@example.com", 25);
+        when(userService.patchUser(eq(1L), any())).thenReturn(Optional.of(updatedUser));
+
+        mockMvc.perform(patch("/users/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Jane"));
+    }
+
+    @Test
+    public void patchUser_withUserNotFound_returnsNotFound() throws Exception {
+        Map<String, Object> updates = Map.of("age", 25);
+        when(userService.patchUser(eq(99L), any())).thenReturn(Optional.empty());
+
+        mockMvc.perform(patch("/users/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Summary
- Implements age validation in the PATCH `/users/{id}` endpoint to enforce a minimum age requirement of 21 years
- Returns a 400 Bad Request response with a descriptive error message when age is less than 21
- Allows PATCH requests that don't include the age field to proceed without validation

## Changes
- `src/main/java/com/example/demo/controller/UserController.java` - Added age validation logic in patchUser method
- `src/main/java/com/example/demo/service/UserService.java` - Updated to support partial user updates
- `src/main/java/com/example/demo/model/User.java` - User model definition
- `src/main/java/com/example/demo/repository/UserRepository.java` - Data access layer
- `src/test/java/com/example/demo/controller/UserControllerPatchValidationTest.java` - Comprehensive unit tests covering validation edge cases

## Testing
1. Run unit tests: `./mvnw test -Dtest=UserControllerPatchValidationTest`
2. Start application: `./mvnw spring-boot:run`
3. Test rejection of age < 21:
   ```bash
   curl -X PATCH http://localhost:8080/users/1 -H 'Content-Type: application/json' -d '{"age": 18}'
   ```
   Expected: 400 Bad Request
4. Test acceptance of age ≥ 21:
   ```bash
   curl -X PATCH http://localhost:8080/users/1 -H 'Content-Type: application/json' -d '{"age": 21}'
   ```
   Expected: 200 OK
5. Test patches without age field:
   ```bash
   curl -X PATCH http://localhost:8080/users/1 -H 'Content-Type: application/json' -d '{"name": "NewName"}'
   ```
   Expected: 200 OK (validation skipped)

## Issue
Closes #10: Add validation in patch api age cannot be less than 21 years.