### PR TITLE
feat(#12): Put validation on Employee patch api if employee is less than 21 years.

### DIFF
--- a/CassandraBootIntegration/src/main/java/com/ranga/controller/EmployeeController.java
+++ b/CassandraBootIntegration/src/main/java/com/ranga/controller/EmployeeController.java
@@ -3,9 +3,13 @@ package com.ranga.controller;
 /**
  * Created by anurag on 05/03/19.
  */
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -53,5 +57,22 @@ public class EmployeeController {
     @RequestMapping(value = "/employee", method = RequestMethod.PUT)
     Employee update(@RequestBody Employee employee) {
         return employeeService.updateEmployee(employee);
+    }
+
+    @RequestMapping(value = "/employee/{id}", method = RequestMethod.PATCH)
+    ResponseEntity<?> patch(@PathVariable("id") int id, @RequestBody Map<String, Object> updates) {
+        if (updates.containsKey("age")) {
+            int age = (Integer) updates.get("age");
+            if (age < 21) {
+                Map<String, String> error = new HashMap<>();
+                error.put("error", "Age cannot be less than 21 years");
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+            }
+        }
+        Employee patched = employeeService.patchEmployee(id, updates);
+        if (patched == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        return ResponseEntity.ok(patched);
     }
 }

--- a/CassandraBootIntegration/src/main/java/com/ranga/service/EmployeeService.java
+++ b/CassandraBootIntegration/src/main/java/com/ranga/service/EmployeeService.java
@@ -4,6 +4,7 @@ package com.ranga.service;
  * Created by anurag on 05/03/19.
  */
 import java.util.List;
+import java.util.Map;
 
 import com.ranga.entity.Employee;
 
@@ -32,7 +33,6 @@ public interface EmployeeService {
      * @param employee
      * @return {@link Employee}
      */
-
     public Employee updateEmployee(Employee employee);
 
     /**
@@ -46,4 +46,12 @@ public interface EmployeeService {
      * @return
      */
     public List<Employee> getAllEmployees();
+
+    /**
+     * Partially update the Employee Information using Id
+     * @param id
+     * @param updates
+     * @return {@link Employee}
+     */
+    public Employee patchEmployee(int id, Map<String, Object> updates);
 }

--- a/CassandraBootIntegration/src/main/java/com/ranga/service/impl/EmployeeServiceImpl.java
+++ b/CassandraBootIntegration/src/main/java/com/ranga/service/impl/EmployeeServiceImpl.java
@@ -4,6 +4,7 @@ package com.ranga.service.impl;
  * Created by anurag on 05/03/19.
  */
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -55,4 +56,24 @@ public class EmployeeServiceImpl implements EmployeeService {
         return employeeDAO.getAllEmployees();
     }
 
+    @Override
+    public Employee patchEmployee(int id, Map<String, Object> updates) {
+        Employee existing = employeeDAO.getEmployee(id);
+        if (existing == null) {
+            return null;
+        }
+        if (updates.containsKey("name")) {
+            existing.setName((String) updates.get("name"));
+        }
+        if (updates.containsKey("age")) {
+            existing.setAge((Integer) updates.get("age"));
+        }
+        if (updates.containsKey("salary")) {
+            Object salaryVal = updates.get("salary");
+            if (salaryVal instanceof Number) {
+                existing.setSalary(((Number) salaryVal).floatValue());
+            }
+        }
+        return employeeDAO.updateEmployee(existing);
+    }
 }


### PR DESCRIPTION
## Summary
- Added age validation to the Employee PATCH API endpoint to ensure age is at least 21 years old
- Returns 400 Bad Request with error message 'Age cannot be less than 21 years' when age validation fails
- Supports partial updates for employee fields (name, age, salary) while maintaining validation on age

## Changes
- `EmployeeController.java`: Added PATCH endpoint `/employee/{id}` with age validation logic
- `EmployeeService.java`: Added `patchEmployee` method signature to the service interface
- `EmployeeServiceImpl.java`: Implemented `patchEmployee` method to handle partial employee updates and persistence

## Testing
1. Start the Spring Boot application with Cassandra running
2. Create an employee: `POST /employee` with body `{"id":1, "name":"John", "age":25, "salary":50000}`
3. Test age < 21: `PATCH /employee/1` with `{"age": 18}` → expect 400 with error message
4. Test age = 20: `PATCH /employee/1` with `{"age": 20}` → expect 400 with error message
5. Test age = 21: `PATCH /employee/1` with `{"age": 21}` → expect 200 OK
6. Test age > 21: `PATCH /employee/1` with `{"age": 30}` → expect 200 OK
7. Test partial update (no age): `PATCH /employee/1` with `{"name": "Jane"}` → expect 200 OK, validation skipped
8. Test non-existent employee: `PATCH /employee/999` with `{"age": 25}` → expect 404 Not Found

## Issue
Closes #12: Put validation on Employee patch api if employee is less than 21 years.