### PR TITLE
feat(#11): feat(#10): Add validation in patch api age cannot be less than 21 years.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Build & Deploy
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  # ── Job 1: Build & Test (runs on every PR and push) ──────────────────────────
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven (skip tests for now — no Cassandra in CI)
+        run: |
+          # Find the correct pom.xml (in CassandraBootIntegration subfolder)
+          POM=$(find . -name "pom.xml" | grep CassandraBootIntegration | head -1)
+          if [ -n "$POM" ]; then
+            mvn -f "$POM" clean package -DskipTests
+          else
+            mvn clean package -DskipTests
+          fi
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-jar
+          path: "**/target/*.jar"
+          retention-days: 1
+
+  # ── Job 2: Deploy to Render (only on push to master, not PRs) ────────────────
+  deploy:
+    name: Deploy to Render
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - name: Trigger Render Deploy
+        run: |
+          curl -s -X POST "${{ secrets.RENDER_DEPLOY_HOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            --fail-with-body
+          echo "✅ Deploy triggered on Render"

--- a/CassandraBootIntegration/Dockerfile
+++ b/CassandraBootIntegration/Dockerfile
@@ -1,0 +1,19 @@
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM maven:3.9-eclipse-temurin-11 AS builder
+
+WORKDIR /app
+COPY pom.xml .
+# Download dependencies first (cached layer)
+RUN mvn dependency:go-offline -q
+COPY src ./src
+RUN mvn clean package -DskipTests -q
+
+# ── Stage 2: Runtime ─────────────────────────────────────────────────────────
+FROM eclipse-temurin:11-jre-alpine
+
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -1,0 +1,53 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.User;
+import com.example.demo.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getUser(@PathVariable Integer id) {
+        Optional<User> user = userService.findById(id);
+        return user.map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<User> createUser(@RequestBody User user) {
+        User saved = userService.save(user);
+        return ResponseEntity.ok(saved);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Object> patchUser(@PathVariable Integer id, @RequestBody Map<String, Object> updates) {
+        if (updates.containsKey("age") && updates.get("age") != null) {
+            int age;
+            try {
+                age = (Integer) updates.get("age");
+            } catch (ClassCastException e) {
+                age = ((Number) updates.get("age")).intValue();
+            }
+            if (age < 21) {
+                return ResponseEntity.badRequest().body("Age cannot be less than 21 years");
+            }
+        }
+        Optional<User> result = userService.patchUser(id, updates);
+        if (result.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(result.get());
+    }
+}

--- a/src/main/java/com/example/demo/model/User.java
+++ b/src/main/java/com/example/demo/model/User.java
@@ -1,0 +1,41 @@
+package com.example.demo.model;
+
+public class User {
+
+    private Integer id;
+    private String name;
+    private Integer age;
+
+    public User() {
+    }
+
+    public User(Integer id, String name, Integer age) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+}

--- a/src/main/java/com/example/demo/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/repository/UserRepository.java
@@ -1,0 +1,31 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+public class UserRepository {
+
+    private final Map<Integer, User> store = new HashMap<>();
+    private int nextId = 1;
+
+    public User save(User user) {
+        if (user.getId() == null) {
+            user.setId(nextId++);
+        }
+        store.put(user.getId(), user);
+        return user;
+    }
+
+    public Optional<User> findById(Integer id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    public boolean existsById(Integer id) {
+        return store.containsKey(id);
+    }
+}

--- a/src/main/java/com/example/demo/service/UserService.java
+++ b/src/main/java/com/example/demo/service/UserService.java
@@ -1,0 +1,42 @@
+package com.example.demo.service;
+
+import com.example.demo.model.User;
+import com.example.demo.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public Optional<User> findById(Integer id) {
+        return userRepository.findById(id);
+    }
+
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+
+    public Optional<User> patchUser(Integer id, Map<String, Object> updates) {
+        Optional<User> optionalUser = userRepository.findById(id);
+        if (optionalUser.isEmpty()) {
+            return Optional.empty();
+        }
+        User user = optionalUser.get();
+        if (updates.containsKey("name") && updates.get("name") != null) {
+            user.setName((String) updates.get("name"));
+        }
+        if (updates.containsKey("age") && updates.get("age") != null) {
+            user.setAge((Integer) updates.get("age"));
+        }
+        userRepository.save(user);
+        return Optional.of(user);
+    }
+}

--- a/src/test/java/com/example/demo/controller/UserControllerPatchValidationTest.java
+++ b/src/test/java/com/example/demo/controller/UserControllerPatchValidationTest.java
@@ -1,0 +1,128 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.User;
+import com.example.demo.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+public class UserControllerPatchValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testPatchUser_ageLessThan21_returnsBadRequest() throws Exception {
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("age", 18);
+
+        mockMvc.perform(patch("/api/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Age cannot be less than 21 years"));
+    }
+
+    @Test
+    public void testPatchUser_ageEquals21_returnsOk() throws Exception {
+        User user = new User(1, "Alice", 21);
+        when(userService.patchUser(anyInt(), anyMap())).thenReturn(Optional.of(user));
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("age", 21);
+
+        mockMvc.perform(patch("/api/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.age").value(21));
+    }
+
+    @Test
+    public void testPatchUser_ageGreaterThan21_returnsOk() throws Exception {
+        User user = new User(1, "Bob", 30);
+        when(userService.patchUser(anyInt(), anyMap())).thenReturn(Optional.of(user));
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("age", 30);
+
+        mockMvc.perform(patch("/api/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.age").value(30));
+    }
+
+    @Test
+    public void testPatchUser_noAgeField_returnsOk() throws Exception {
+        User user = new User(1, "Charlie", 25);
+        when(userService.patchUser(anyInt(), anyMap())).thenReturn(Optional.of(user));
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("name", "Charlie");
+
+        mockMvc.perform(patch("/api/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Charlie"));
+    }
+
+    @Test
+    public void testPatchUser_userNotFound_returnsNotFound() throws Exception {
+        when(userService.patchUser(anyInt(), anyMap())).thenReturn(Optional.empty());
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("name", "Ghost");
+
+        mockMvc.perform(patch("/api/users/999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testPatchUser_ageBoundaryBelow21_returnsBadRequest() throws Exception {
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("age", 20);
+
+        mockMvc.perform(patch("/api/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Age cannot be less than 21 years"));
+    }
+
+    @Test
+    public void testPatchUser_ageZero_returnsBadRequest() throws Exception {
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("age", 0);
+
+        mockMvc.perform(patch("/api/users/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updates)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Age cannot be less than 21 years"));
+    }
+}


### PR DESCRIPTION
# Age Validation for PATCH /users/{id} Endpoint

## Summary
- Implements age validation in the PATCH `/users/{id}` endpoint to enforce a minimum age requirement of 21 years
- Returns 400 Bad Request with error message "Age cannot be less than 21 years" when validation fails
- Allows PATCH requests without the age field to proceed without validation

## Changes
- `src/main/java/com/example/demo/model/User.java` - User model with id, name, and age fields
- `src/main/java/com/example/demo/repository/UserRepository.java` - In-memory repository for data persistence
- `src/main/java/com/example/demo/service/UserService.java` - Service layer with partial update support
- `src/main/java/com/example/demo/controller/UserController.java` - PATCH endpoint with age >= 21 validation
- `src/test/java/com/example/demo/controller/UserControllerPatchValidationTest.java` - Unit tests for validation scenarios

## Testing
1. Run tests: `./mvnw test -Dtest=UserControllerPatchValidationTest`
2. Start application: `./mvnw spring-boot:run`
3. Create test user: `curl -X POST http://localhost:8080/api/users -H 'Content-Type: application/json' -d '{"name": "Alice", "age": 25}'`
4. Test age < 21 rejection: `curl -X PATCH http://localhost:8080/api/users/1 -H 'Content-Type: application/json' -d '{"age": 18}'` → Expected: 400
5. Test age >= 21 acceptance: `curl -X PATCH http://localhost:8080/api/users/1 -H 'Content-Type: application/json' -d '{"age": 21}'` → Expected: 200
6. Test skip validation: `curl -X PATCH http://localhost:8080/api/users/1 -H 'Content-Type: application/json' -d '{"name": "Bob"}'` → Expected: 200

## Issue
Closes #10