### PR TITLE
feat(#21): Employee delete api should have soft delete not hard delete

### DIFF
--- a/CassandraBootIntegration/src/main/java/com/ranga/dao/impl/EmployeeDAOImpl.java
+++ b/CassandraBootIntegration/src/main/java/com/ranga/dao/impl/EmployeeDAOImpl.java
@@ -4,6 +4,7 @@ package com.ranga.dao.impl;
  * Created by anurag on 05/03/19.
  */
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -24,12 +25,17 @@ public class EmployeeDAOImpl implements EmployeeDAO {
 
     @Override
     public Employee createEmployee(Employee employee) {
+        employee.setIsActive(1);
         return myCassandraTemplate.create(employee);
     }
 
     @Override
     public Employee getEmployee(int id) {
-        return myCassandraTemplate.findById(id, Employee.class);
+        Employee employee = myCassandraTemplate.findById(id, Employee.class);
+        if (employee != null && employee.getIsActive() == 0) {
+            return null;
+        }
+        return employee;
     }
 
     @Override
@@ -39,11 +45,18 @@ public class EmployeeDAOImpl implements EmployeeDAO {
 
     @Override
     public void deleteEmployee(int id) {
-        myCassandraTemplate.deleteById(id, Employee.class);
+        Employee employee = myCassandraTemplate.findById(id, Employee.class);
+        if (employee != null) {
+            employee.setIsActive(0);
+            myCassandraTemplate.update(employee, Employee.class);
+        }
     }
 
     @Override
     public List<Employee> getAllEmployees() {
-        return myCassandraTemplate.findAll(Employee.class);
+        List<Employee> allEmployees = myCassandraTemplate.findAll(Employee.class);
+        return allEmployees.stream()
+                .filter(emp -> emp.getIsActive() == 1)
+                .collect(Collectors.toList());
     }
 }

--- a/CassandraBootIntegration/src/main/java/com/ranga/entity/Employee.java
+++ b/CassandraBootIntegration/src/main/java/com/ranga/entity/Employee.java
@@ -27,6 +27,9 @@ public class Employee {
     @Column(value = "salary")
     private float salary;
 
+    @Column(value = "is_active")
+    private int isActive = 1;
+
     public Employee() {
         super();
     }
@@ -37,6 +40,7 @@ public class Employee {
         this.name = name;
         this.age = age;
         this.salary = salary;
+        this.isActive = 1;
     }
 
     public long getId() {
@@ -71,9 +75,17 @@ public class Employee {
         this.salary = salary;
     }
 
+    public int getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(int isActive) {
+        this.isActive = isActive;
+    }
+
     @Override
     public String toString() {
         return "Employee [id=" + id + ", name=" + name + ", age=" + age
-                + ", salary=" + salary + "]";
+                + ", salary=" + salary + ", isActive=" + isActive + "]";
     }
 }

--- a/CassandraBootIntegration/src/main/java/com/ranga/service/EmployeeService.java
+++ b/CassandraBootIntegration/src/main/java/com/ranga/service/EmployeeService.java
@@ -4,6 +4,7 @@ package com.ranga.service;
  * Created by anurag on 05/03/19.
  */
 import java.util.List;
+import java.util.Map;
 
 import com.ranga.entity.Employee;
 
@@ -32,18 +33,25 @@ public interface EmployeeService {
      * @param employee
      * @return {@link Employee}
      */
-
     public Employee updateEmployee(Employee employee);
 
     /**
-     * Deleting the Employee Information using Id
+     * Deleting the Employee Information using Id (soft delete)
      * @param id
      */
     public void deleteEmployee(int id);
 
     /**
-     * Getting the All Employees information
+     * Getting the All Employees information (only active)
      * @return
      */
     public List<Employee> getAllEmployees();
+
+    /**
+     * Partially update Employee information
+     * @param id
+     * @param updates
+     * @return {@link Employee}
+     */
+    public Employee patchEmployee(int id, Map<String, Object> updates);
 }

--- a/CassandraBootIntegration/src/main/java/com/ranga/service/impl/EmployeeServiceImpl.java
+++ b/CassandraBootIntegration/src/main/java/com/ranga/service/impl/EmployeeServiceImpl.java
@@ -4,6 +4,7 @@ package com.ranga.service.impl;
  * Created by anurag on 05/03/19.
  */
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -55,4 +56,24 @@ public class EmployeeServiceImpl implements EmployeeService {
         return employeeDAO.getAllEmployees();
     }
 
+    @Override
+    public Employee patchEmployee(int id, Map<String, Object> updates) {
+        Employee employee = employeeDAO.getEmployee(id);
+        if (employee == null) {
+            return null;
+        }
+        if (updates.containsKey("name")) {
+            employee.setName((String) updates.get("name"));
+        }
+        if (updates.containsKey("age")) {
+            employee.setAge((Integer) updates.get("age"));
+        }
+        if (updates.containsKey("salary")) {
+            Object salaryObj = updates.get("salary");
+            if (salaryObj instanceof Number) {
+                employee.setSalary(((Number) salaryObj).floatValue());
+            }
+        }
+        return employeeDAO.updateEmployee(employee);
+    }
 }


### PR DESCRIPTION
## Summary
- Implemented soft delete functionality for the Employee API by adding an `isActive` field to track deletion status instead of physically removing records
- Modified the delete operation to set `isActive = 0` and updated retrieval methods to filter out soft-deleted employees
- Added `patchEmployee` method to the service layer to support the existing PATCH controller endpoint

## Changes
- `Employee.java` — Added `isActive` field (defaults to 1) to track active/deleted status
- `EmployeeDAOImpl.java` — Modified `deleteEmployee()` to perform soft delete; updated `getAllEmployees()` and `getEmployee()` to filter soft-deleted records
- `EmployeeService.java` — Added `patchEmployee()` method signature
- `EmployeeServiceImpl.java` — Implemented `patchEmployee()` method

## Testing
1. Start the application with Cassandra running
2. Add the `is_active` column to the employee table: `ALTER TABLE employee ADD is_active int;`
3. Create an employee via POST /employee
4. Verify the employee is returned with `isActive=1` via GET /employee/1
5. Delete the employee via DELETE /employee/1
6. Verify GET /employee/1 returns null/404 and the employee is excluded from GET /employee
7. Confirm in Cassandra that the record persists with `is_active=0`: `SELECT * FROM employee WHERE id=1;`
8. Create a new employee and verify `isActive=1` by default

## Issue
Closes #21: Employee delete api should have soft delete not hard delete